### PR TITLE
fix: use tmpdir instead of homedir

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,6 @@
 var fs   = require("fs"),
     path = require("path"),
+    os = require('os'),
     exec = require('child_process').exec;
 
 
@@ -30,7 +31,7 @@ module.exports.getUserHome = getUserHome;
 
 
 module.exports.getAnyProxyHome = function(){
-    var home = path.join(util.getUserHome(),"/.anyproxy/");
+    var home = path.join(os.tmpdir(),"/.anyproxy/");
 
     if(!fs.existsSync(home)){
         try{


### PR DESCRIPTION
anyproxy 会写很多缓存，把硬盘打满了，将 homedir 改成 tmpdir